### PR TITLE
Add mysql2 adapter

### DIFF
--- a/lib/rescue_unique_constraint.rb
+++ b/lib/rescue_unique_constraint.rb
@@ -1,6 +1,7 @@
 require 'rescue_unique_constraint/version'
 require 'rescue_unique_constraint/index'
 require 'rescue_unique_constraint/rescue_handler'
+require 'rescue_unique_constraint/adapter/mysql_adapter'
 require 'rescue_unique_constraint/adapter/postgresql_adapter'
 require 'rescue_unique_constraint/adapter/sqlite_adapter'
 require 'active_record'

--- a/lib/rescue_unique_constraint/adapter/mysql_adapter.rb
+++ b/lib/rescue_unique_constraint/adapter/mysql_adapter.rb
@@ -1,0 +1,9 @@
+module RescueUniqueConstraint
+  module Adapter
+    class MysqlAdapter
+      def index_error?(index, error_message)
+        error_message[/#{index.name}/]
+      end
+    end
+  end
+end

--- a/lib/rescue_unique_constraint/rescue_handler.rb
+++ b/lib/rescue_unique_constraint/rescue_handler.rb
@@ -25,6 +25,8 @@ module RescueUniqueConstraint
     def database_adapter
       @_database_adapter ||= (
         case database_name
+        when :mysql2
+          Adapter::MysqlAdapter.new
         when :postgresql
           Adapter::PostgresqlAdapter.new
         when :sqlite


### PR DESCRIPTION
I've just added an adapter compatible with MySQL. Iin fact, is a copy of PostgreSQL adapter, so maybe could be interesting use PostgreeSQL adapter for all database types compatibles with it. But well, I think maybe can be better for now keep each database type with his own adapter.

It works for me, I hope you find it useful.