### PR TITLE
Add Rails 7 support

### DIFF
--- a/lib/rescue_unique_constraint/version.rb
+++ b/lib/rescue_unique_constraint/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RescueUniqueConstraint
-  VERSION = "1.9.0"
+  VERSION = "1.10.0"
 end

--- a/rescue_unique_constraint.gemspec
+++ b/rescue_unique_constraint.gemspec
@@ -11,14 +11,14 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{Turns ActiveRecord::RecordNotUnique errors into ActiveRecord errors}
   spec.description   = %q{Rescues unique constraint violations and turns them into ActiveRecord errors}
   spec.homepage      = "https://github.com/reverbdotcom/rescue_unique_contraint"
-  spec.license       = "Apache 2.0"
+  spec.license       = "Apache-2.0"
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">= 3.2", "< 7"
+  spec.add_dependency "activerecord", ">= 3.2", "< 8"
 
   spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", "~> 10.5"


### PR DESCRIPTION
I couldn't use the gem on a Rails 7 project, as it was limited to `activerecord <7`. I bumped the limit to `<8`, and tested on a Rails 7.0.6 app with postgres.

While building the gem I got a warning about the license being invalid:
```
WARNING:  license value 'Apache 2.0' is invalid.  Use a license identifier from
http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
Did you mean 'Apache-2.0'?
```
so I replaced the space with a `-` in `Apache-2.0`.

I also bumped the gem version from `1.9.0` to `1.10.0`.